### PR TITLE
Implement proper GQL response handling when response contains errors

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -138,6 +138,11 @@ namespace TarkovPriceViewer
                         //responseContent = JToken.Parse(responseContent).ToString();
 
                         tarkovAPI = JsonConvert.DeserializeObject<TarkovAPI.Data>(responseContent);
+						// Check to make sure the response didn't return an error schema
+						if(tarkovAPI.items == null){
+							TarkovPriceViewer.ResponseShell temp = JsonConvert.DeserializeObject<TarkovPriceViewer.ResponseShell>(responseContent);
+							tarkovAPI = temp.data;
+						}
                         APILastUpdated = DateTime.Now;
                         finishloadingAPI = true;
                         Debug.WriteLine("\n--> TarkovDev API Updated!");
@@ -157,6 +162,11 @@ namespace TarkovPriceViewer
                 {
                     string responseContent = File.ReadAllText(@"Resources\TarkovAPI.json");
                     tarkovAPI = JsonConvert.DeserializeObject<TarkovAPI.Data>(responseContent);
+					// Check to make sure the response didn't return an error schema
+					if(tarkovAPI.items == null){
+						TarkovPriceViewer.ResponseShell temp = JsonConvert.DeserializeObject<TarkovPriceViewer.ResponseShell>(responseContent);
+						tarkovAPI = temp.data;
+					}
                     Debug.WriteLine("\n--> TarkovDev API Loaded from local File! \n--> " + LastUpdated(APILastUpdated) + "\n\n");
                     finishloadingAPI = true;
                 }

--- a/TarkovAPI.cs
+++ b/TarkovAPI.cs
@@ -4,6 +4,25 @@ using System.Collections.Generic;
 
 namespace TarkovPriceViewer
 {
+	public class ResponseShell
+    {
+        public List<GQLError> errors { get; set; }
+
+        public TarkovAPI.Data data { get; set; }
+
+        public class GQLError
+        {
+            public string message { get; set; }
+            public List<Location> locations { get; set; }
+            public class Location
+            {
+                public int line { get; set; }
+                public int column { get; set; }
+            }
+            public List<Object> path;
+        }
+    }
+
     public class TarkovAPI
     {
         public class BartersFor


### PR DESCRIPTION
Fixes #11 by implementing a check in `UpdateItemListAPI()`. All this does is add a check to see if `tarkovAPI.items` is still null after the first deserialization attempt (to Fig 1)- if so, it attempts to deserialize it again using the error schema (Fig 2).

From the issue, 
```jsonc
// Fig 1
{
  "items": [/*...*/],
  "hideoutStations": [/*...],
}
```
```jsonc
// Fig 2
{
  "errors": [
    {/*...*/}
  ],
  "data": {
    "items": [/*...*/],
    "hideoutStations": [/*...*/],
  }
}
```