### PR TITLE
feat: allow configuring mouse buttons as overlay keybinds

### DIFF
--- a/KeyPressCheck.cs
+++ b/KeyPressCheck.cs
@@ -4,12 +4,18 @@ namespace TarkovPriceViewer
 {
     public partial class KeyPressCheck : Form
     {
+        private const int MOUSE_LEFT = 1001;
+        private const int MOUSE_RIGHT = 1002;
+        private const int MOUSE_MIDDLE = 1003;
+        private const int MOUSE_X1 = 1004;
+        private const int MOUSE_X2 = 1005;
         private int button;
 
         public KeyPressCheck(int button)
         {
             this.button = button;
             InitializeComponent();
+            this.MouseUp += KeyPressCheck_MouseUp;
         }
 
         private void KeyPressCheck_FormClosed(object sender, FormClosedEventArgs e)
@@ -46,5 +52,53 @@ namespace TarkovPriceViewer
                 this.Close();
             }
         }
+
+        private void KeyPressCheck_MouseUp(object sender, MouseEventArgs e)
+        {
+            int mouseCode = 0;
+
+            switch (e.Button)
+            {
+                case MouseButtons.Left:
+                    mouseCode = MOUSE_LEFT;
+                    break;
+                case MouseButtons.Right:
+                    mouseCode = MOUSE_RIGHT;
+                    break;
+                case MouseButtons.Middle:
+                    mouseCode = MOUSE_MIDDLE;
+                    break;
+                case MouseButtons.XButton1:
+                    mouseCode = MOUSE_X1;
+                    break;
+                case MouseButtons.XButton2:
+                    mouseCode = MOUSE_X2;
+                    break;
+            }
+
+            if (mouseCode != 0)
+            {
+                switch (button)
+                {
+                    case 1:
+                        Program.settings["ShowOverlay_Key"] = mouseCode.ToString();
+                        break;
+                    case 2:
+                        Program.settings["HideOverlay_Key"] = mouseCode.ToString();
+                        break;
+                    case 3:
+                        Program.settings["CompareOverlay_Key"] = mouseCode.ToString();
+                        break;
+                }
+
+                if (Owner != null)
+                {
+                    ((MainForm)Owner).ChangePressKeyData(null);
+                }
+
+                this.Close();
+            }
+        }
     }
 }
+


### PR DESCRIPTION
## Summary

- Add support for binding mouse buttons (Left, Right, Middle, X1, X2) as overlay hotkeys.
- Display mouse bindings with readable labels in the settings UI.
- Share the same handling logic for keyboard and mouse triggers.
- Keep the mouse hook active while still respecting the “Close overlay when mouse moved” option.

## Changes

- **KeyPressCheck**
  - Extend keybind dialog to capture mouse button clicks in addition to keyboard keys.
  - Store mouse binds in `Program.settings["ShowOverlay_Key"]`, `["HideOverlay_Key"]`, `["CompareOverlay_Key"]` using special integer codes.
  - Notify [MainForm](MainForm.cs) with [ChangePressKeyData(null)](MainForm.cs) when a mouse button is bound.

- **MainForm**
  - Add constants and Win32 mouse message handling for:
    - `WM_LBUTTONUP`, `WM_RBUTTONUP`, `WM_MBUTTONUP`, `WM_XBUTTONUP`
    - Mouse codes: `MOUSE_LEFT`, `MOUSE_RIGHT`, `MOUSE_MIDDLE`, `MOUSE_X1`, `MOUSE_X2`
  - Always install the mouse hook; use the `CloseOverlayWhenMouseMoved` setting only to control movement-based closing.
  - Introduce [HandleGlobalKeyOrMouse(int code)](MainForm.cs) to centralize show/hide/compare logic for both keyboard and mouse inputs.
  - Update [hookMouseProc](MainForm.cs) to:
    - Close overlays on mouse movement if enabled.
    - Map mouse button up events to the mouse key codes and call [HandleGlobalKeyOrMouse](MainForm.cs).
  - Add [GetKeybindText(string value)](MainForm.cs) to:
    - Render special mouse codes as `Mouse Left`, `Mouse Right`, `Mouse Middle`, `Mouse X1`, `Mouse X2`.
    - Fallback to normal `Keys` string for keyboard key codes.
  - Use [GetKeybindText](MainForm.cs) when initializing `ShowOverlay_Button`, `HideOverlay_Button`, and `CompareOverlay_Button`.
  - Update [ChangePressKeyData](MainForm.cs) to:
    - Set `press_key_control.Text` when a keyboard key is pressed.
    - Refresh all three button texts from settings via [GetKeybindText](MainForm.cs) when a mouse bind is set (null keycode).

## Motivation

- Allow users to trigger overlays with common gaming mouse buttons without relying solely on keyboard keys.
- Improve usability by clearly showing mouse-based keybinds in the UI.
- Keep hotkey handling maintainable by sharing logic between keyboard and mouse inputs.

## Screenshots

<img width="527" height="469" alt="mouse" src="https://github.com/user-attachments/assets/414e5bf3-d33d-420c-ab14-437dec2f4589" />